### PR TITLE
rate-limit

### DIFF
--- a/src/app/api/rate-limit/route.ts
+++ b/src/app/api/rate-limit/route.ts
@@ -1,0 +1,28 @@
+import { SERVICE_Call__getRateLimit } from '@/server/services/rateLimit'
+import { AUTH_NO_TOKEN_ERROR_RES, checkAuthHeaders } from '@/server/utils/authHeaders'
+import { SHARED_APIFields__RateLimit } from '@/shared/models/apiFields/rateLimit'
+
+/*
+Requires authentication
+Returns rate limit information
+*/
+
+export const GET = async (request: Request): Promise<Response> => {
+    console.log('GET /api/rate-limit')
+
+    const token = checkAuthHeaders(request)
+    if (token === undefined) {
+        return new Response(JSON.stringify(AUTH_NO_TOKEN_ERROR_RES), {
+            status: 401,
+        })
+    }
+
+    const rateLimitRes: SHARED_APIFields__RateLimit = await SERVICE_Call__getRateLimit(token)
+    const { success, rateLimit } = rateLimitRes
+
+    const status = !success || rateLimit === undefined ? 400 : 200
+
+    return new Response(JSON.stringify(rateLimitRes), {
+        status: status,
+    })
+}

--- a/src/app/api/rate-limit/route.ts
+++ b/src/app/api/rate-limit/route.ts
@@ -18,9 +18,9 @@ export const GET = async (request: Request): Promise<Response> => {
     }
 
     const rateLimitRes: SHARED_APIFields__RateLimit = await SERVICE_Call__getRateLimit(token)
-    const { success, rateLimit } = rateLimitRes
+    const { success, rateLimitClientInfo } = rateLimitRes
 
-    const status = !success || rateLimit === undefined ? 400 : 200
+    const status = !success || rateLimitClientInfo === undefined ? 400 : 200
 
     return new Response(JSON.stringify(rateLimitRes), {
         status: status,

--- a/src/app/api/rate-limit/route.ts
+++ b/src/app/api/rate-limit/route.ts
@@ -1,4 +1,4 @@
-import { SERVICE_Call__getRateLimit } from '@/server/services/rateLimit'
+import { SERVICE_Call__getRateLimitViaAPI } from '@/server/services/rateLimit'
 import { AUTH_NO_TOKEN_ERROR_RES, checkAuthHeaders } from '@/server/utils/authHeaders'
 import { SHARED_APIFields__RateLimit } from '@/shared/models/apiFields/rateLimit'
 
@@ -17,7 +17,7 @@ export const GET = async (request: Request): Promise<Response> => {
         })
     }
 
-    const rateLimitRes: SHARED_APIFields__RateLimit = await SERVICE_Call__getRateLimit(token)
+    const rateLimitRes: SHARED_APIFields__RateLimit = await SERVICE_Call__getRateLimitViaAPI(token)
     const { success, rateLimitClientInfo } = rateLimitRes
 
     const status = !success || rateLimitClientInfo === undefined ? 400 : 200

--- a/src/client/components/Pages/Auth/Repos/LifetimeStats/LifetimeStats.tsx
+++ b/src/client/components/Pages/Auth/Repos/LifetimeStats/LifetimeStats.tsx
@@ -5,7 +5,7 @@ import React from 'react'
 import LanguageData from './LanguageData'
 import RepoCell from './RepoCell'
 
-import { SHARED_Model__LifetimeStats } from '@/shared/models/apiFields/lifetimeStats'
+import { SHARED_Model__LifetimeStats } from '@/shared/models/models/Stats'
 import { kbToStr } from '@/shared/utils/toBytesStr'
 
 interface LifetimeStatsProps {

--- a/src/client/components/Pages/Auth/Repos/Repos.tsx
+++ b/src/client/components/Pages/Auth/Repos/Repos.tsx
@@ -6,7 +6,7 @@ import LifetimeStats from './LifetimeStats'
 
 import { useAuth } from '@/client/components/Wrappers/AuthProvider'
 import { lifetimeStatsAPI } from '@/client/lib/authAPI'
-import { SHARED_Model__LifetimeStats } from '@/shared/models/apiFields/lifetimeStats'
+import { SHARED_Model__LifetimeStats } from '@/shared/models/models/Stats'
 
 export const Repos: React.FC = () => {
     const { accessToken } = useAuth()

--- a/src/client/components/Wrappers/AuthWrapper/AuthWrapper.tsx
+++ b/src/client/components/Wrappers/AuthWrapper/AuthWrapper.tsx
@@ -1,8 +1,7 @@
-import React, { useEffect, useState } from 'react'
+import React, { useEffect } from 'react'
 import { usePathname, useRouter } from 'next/navigation'
 
 import { AuthStatus, useAuth } from '@/client/components/Wrappers/AuthProvider'
-import { rateLimitAPI } from '@/client/lib/authAPI'
 import { CLIENT_AUTH_ROUTES, CLIENT_UNAUTH_ROUTES } from '@/client/routes'
 
 /*
@@ -12,12 +11,6 @@ Must be descendent of `AuthProvider`
 
 interface AuthWrapperProps {
     children: React.ReactNode
-}
-
-enum RateLimitState {
-    INITIALIZING = 'INITIALIZING',
-    OK = 'OK',
-    LIMITED = 'LIMITED',
 }
 
 const isAuthAllowedOnRoute = (pathname: string): boolean => {
@@ -35,29 +28,11 @@ export const AuthWrapper: React.FC<AuthWrapperProps> = (props) => {
     const router = useRouter()
     const pathname = usePathname()
 
-    const [rateLimitState, setRateLimitState] = useState<RateLimitState>(RateLimitState.INITIALIZING)
-
     useEffect(() => {
-        const getRateLimit = async (accessToken: string) => {
-            const { success: rateLimitSuccess, error: rateLimitError, rateLimit } = await rateLimitAPI(accessToken)
-            if (!rateLimitSuccess || rateLimit === undefined) {
-                console.error(rateLimitError)
-                return setRateLimitState(RateLimitState.LIMITED)
-            }
-
-            console.log(rateLimit)
-            const { limit, used, remaining } = rateLimit
-            setRateLimitState(remaining <= 4996 ? RateLimitState.LIMITED : RateLimitState.OK)
-        }
-
         if (authStatus === AuthStatus.UNAUTH && !isUnauthAllowedOnRoute(pathname)) {
             router.push('/login')
         } else if (authStatus === AuthStatus.AUTH && !isAuthAllowedOnRoute(pathname)) {
             router.push('/')
-        } else if (authStatus === AuthStatus.AUTH && accessToken !== undefined) {
-            getRateLimit(accessToken)
-        } else {
-            setRateLimitState(RateLimitState.OK)
         }
     }, [router, pathname, authStatus, accessToken])
 
@@ -76,14 +51,6 @@ export const AuthWrapper: React.FC<AuthWrapperProps> = (props) => {
     }
 
     console.log(`[AuthWrapper] rendering ${pathname} with ${authStatus}`)
-
-    if (rateLimitState === RateLimitState.INITIALIZING) {
-        return <div>Checking rate limits...</div>
-    }
-
-    if (rateLimitState === RateLimitState.LIMITED) {
-        return <div>Rate limited!</div>
-    }
 
     return <>{children}</>
 }

--- a/src/client/components/Wrappers/AuthWrapper/AuthWrapper.tsx
+++ b/src/client/components/Wrappers/AuthWrapper/AuthWrapper.tsx
@@ -1,7 +1,8 @@
-import React, { useEffect } from 'react'
+import React, { useEffect, useState } from 'react'
 import { usePathname, useRouter } from 'next/navigation'
 
 import { AuthStatus, useAuth } from '@/client/components/Wrappers/AuthProvider'
+import { rateLimitAPI } from '@/client/lib/authAPI'
 import { CLIENT_AUTH_ROUTES, CLIENT_UNAUTH_ROUTES } from '@/client/routes'
 
 /*
@@ -11,6 +12,12 @@ Must be descendent of `AuthProvider`
 
 interface AuthWrapperProps {
     children: React.ReactNode
+}
+
+enum RateLimitState {
+    INITIALIZING = 'INITIALIZING',
+    OK = 'OK',
+    LIMITED = 'LIMITED',
 }
 
 const isAuthAllowedOnRoute = (pathname: string): boolean => {
@@ -24,17 +31,35 @@ const isUnauthAllowedOnRoute = (pathname: string): boolean => {
 export const AuthWrapper: React.FC<AuthWrapperProps> = (props) => {
     const { children } = props
 
-    const { authStatus } = useAuth()
+    const { authStatus, accessToken } = useAuth()
     const router = useRouter()
     const pathname = usePathname()
 
+    const [rateLimitState, setRateLimitState] = useState<RateLimitState>(RateLimitState.INITIALIZING)
+
     useEffect(() => {
+        const getRateLimit = async (accessToken: string) => {
+            const { success: rateLimitSuccess, error: rateLimitError, rateLimit } = await rateLimitAPI(accessToken)
+            if (!rateLimitSuccess || rateLimit === undefined) {
+                console.error(rateLimitError)
+                return setRateLimitState(RateLimitState.LIMITED)
+            }
+
+            console.log(rateLimit)
+            const { limit, used, remaining } = rateLimit
+            setRateLimitState(remaining <= 4996 ? RateLimitState.LIMITED : RateLimitState.OK)
+        }
+
         if (authStatus === AuthStatus.UNAUTH && !isUnauthAllowedOnRoute(pathname)) {
             router.push('/login')
         } else if (authStatus === AuthStatus.AUTH && !isAuthAllowedOnRoute(pathname)) {
             router.push('/')
+        } else if (authStatus === AuthStatus.AUTH && accessToken !== undefined) {
+            getRateLimit(accessToken)
+        } else {
+            setRateLimitState(RateLimitState.OK)
         }
-    }, [router, pathname, authStatus])
+    }, [router, pathname, authStatus, accessToken])
 
     // TODO: loading state
     // remember this is immediately returned from server before hydration
@@ -51,6 +76,14 @@ export const AuthWrapper: React.FC<AuthWrapperProps> = (props) => {
     }
 
     console.log(`[AuthWrapper] rendering ${pathname} with ${authStatus}`)
+
+    if (rateLimitState === RateLimitState.INITIALIZING) {
+        return <div>Checking rate limits...</div>
+    }
+
+    if (rateLimitState === RateLimitState.LIMITED) {
+        return <div>Rate limited!</div>
+    }
 
     return <>{children}</>
 }

--- a/src/client/components/Wrappers/ClientWrapper.tsx
+++ b/src/client/components/Wrappers/ClientWrapper.tsx
@@ -4,6 +4,7 @@ import React from 'react'
 
 import { AuthWrapper } from './AuthWrapper/AuthWrapper'
 import Main from './MainWrapper'
+import RateLimitWrapper from './RateLimitWrapper'
 
 import { AuthProvider } from '@/client/components/Wrappers/AuthProvider'
 import Nav from '@/client/components/Wrappers/Nav'
@@ -19,7 +20,9 @@ export const ClientWrapper: React.FC<ClientWrapperProps> = (props: ClientWrapper
         <AuthProvider>
             <Nav />
             <Main>
-                <AuthWrapper>{children}</AuthWrapper>
+                <AuthWrapper>
+                    <RateLimitWrapper>{children}</RateLimitWrapper>
+                </AuthWrapper>
             </Main>
         </AuthProvider>
     )

--- a/src/client/components/Wrappers/RateLimitWrapper/RateLimitWrapper.tsx
+++ b/src/client/components/Wrappers/RateLimitWrapper/RateLimitWrapper.tsx
@@ -1,0 +1,86 @@
+import React, { useEffect, useReducer, useState } from 'react'
+import { usePathname } from 'next/navigation'
+
+import { AuthStatus, useAuth } from '../AuthProvider'
+
+import { RATE_LIMIT_AUTH_ERROR, RATE_LIMIT_AUTH_RESPONSE, RATE_LIMIT_LOADING, RATE_LIMIT_UNAUTH } from './actions'
+import { reducer } from './reducer'
+
+import { rateLimitAPI } from '@/client/lib/authAPI'
+import { SHARED_Model__RateLimit } from '@/shared/models/models/RateLimit'
+
+/*
+Should only be rendered after client-side auth redirects in AuthWrapper
+*/
+
+interface RateLimitWrapperProps {
+    children: React.ReactNode
+}
+
+export interface RateLimitWrapperState {
+    isLoading: boolean
+    error?: string
+    rateLimit?: SHARED_Model__RateLimit
+}
+
+const initialRateLimitWrapperState: RateLimitWrapperState = {
+    isLoading: true,
+    error: undefined,
+    rateLimit: undefined,
+}
+
+export const RateLimitWrapper: React.FC<RateLimitWrapperProps> = (props) => {
+    const { children } = props
+
+    const [state, dispatch] = useReducer(reducer, initialRateLimitWrapperState)
+    const { isLoading, error, rateLimit } = state
+
+    const { authStatus, accessToken } = useAuth()
+    const pathname = usePathname()
+    // additional state needed: do not render new pathname until rate limits have been polled
+    // race condition: if previously set rateLimit to !undefined, before dispatch(LOADING) updates, allows child render, then sets to loading
+    // -> makes page query and rate limit query
+    const [lastPathname, setPrevPathname] = useState<string>(pathname)
+
+    useEffect(() => {
+        const getRateLimit = async (accessToken: string) => {
+            dispatch({ type: RATE_LIMIT_LOADING })
+            const {
+                success: rateLimitSuccess,
+                error: rateLimitError,
+                rateLimit: updatedRateLimit,
+            } = await rateLimitAPI(accessToken)
+
+            if (!rateLimitSuccess || updatedRateLimit === undefined) {
+                dispatch({ type: RATE_LIMIT_AUTH_ERROR, error: rateLimitError })
+            } else {
+                dispatch({ type: RATE_LIMIT_AUTH_RESPONSE, rateLimit: updatedRateLimit })
+            }
+
+            setPrevPathname(pathname)
+        }
+
+        if (authStatus !== AuthStatus.AUTH) {
+            dispatch({ type: RATE_LIMIT_UNAUTH })
+        } else if (authStatus === AuthStatus.AUTH && accessToken !== undefined) {
+            getRateLimit(accessToken)
+        }
+    }, [authStatus, accessToken, pathname])
+
+    // TODO: handle this upstream? (only render RateLimitWrapper under AUTH in ClientWrappers/AuthWrapper?)
+    if (authStatus !== AuthStatus.AUTH) {
+        return <>{children}</>
+    }
+
+    // prevent state update dispatch race condition
+    if (isLoading || pathname !== lastPathname) {
+        return <div>Checking rate limits...</div>
+    }
+
+    if (rateLimit === undefined) {
+        return <div>Rate limit error: {error}</div>
+    }
+
+    console.log(`[RateLimitWrapper] rendering ${pathname}`)
+    return <>{children}</>
+}

--- a/src/client/components/Wrappers/RateLimitWrapper/RateLimitWrapper.tsx
+++ b/src/client/components/Wrappers/RateLimitWrapper/RateLimitWrapper.tsx
@@ -7,7 +7,7 @@ import { RATE_LIMIT_AUTH_ERROR, RATE_LIMIT_AUTH_RESPONSE, RATE_LIMIT_LOADING, RA
 import { reducer } from './reducer'
 
 import { rateLimitAPI } from '@/client/lib/authAPI'
-import { SHARED_Model__RateLimit } from '@/shared/models/models/RateLimit'
+import { SHARED_Model__RateLimitClientInfo } from '@/shared/models/models/RateLimit'
 
 /*
 Should only be rendered after client-side auth redirects in AuthWrapper
@@ -20,20 +20,20 @@ interface RateLimitWrapperProps {
 export interface RateLimitWrapperState {
     isLoading: boolean
     error?: string
-    rateLimit?: SHARED_Model__RateLimit
+    rateLimitInfo?: SHARED_Model__RateLimitClientInfo
 }
 
 const initialRateLimitWrapperState: RateLimitWrapperState = {
     isLoading: true,
     error: undefined,
-    rateLimit: undefined,
+    rateLimitInfo: undefined,
 }
 
 export const RateLimitWrapper: React.FC<RateLimitWrapperProps> = (props) => {
     const { children } = props
 
     const [state, dispatch] = useReducer(reducer, initialRateLimitWrapperState)
-    const { isLoading, error, rateLimit } = state
+    const { isLoading, error, rateLimitInfo } = state
 
     const { authStatus, accessToken } = useAuth()
     const pathname = usePathname()
@@ -48,7 +48,7 @@ export const RateLimitWrapper: React.FC<RateLimitWrapperProps> = (props) => {
             const {
                 success: rateLimitSuccess,
                 error: rateLimitError,
-                rateLimit: updatedRateLimit,
+                rateLimitClientInfo: updatedRateLimit,
             } = await rateLimitAPI(accessToken)
 
             if (!rateLimitSuccess || updatedRateLimit === undefined) {
@@ -77,10 +77,16 @@ export const RateLimitWrapper: React.FC<RateLimitWrapperProps> = (props) => {
         return <div>Checking rate limits...</div>
     }
 
-    if (rateLimit === undefined) {
+    if (rateLimitInfo === undefined) {
         return <div>Rate limit error: {error}</div>
     }
 
-    console.log(`[RateLimitWrapper] rendering ${pathname}`)
+    const { isRateLimited, rateLimitedMessage, rateOkMessage } = rateLimitInfo
+
+    if (isRateLimited) {
+        return <div>{rateLimitedMessage}</div>
+    }
+
+    console.log(`[RateLimitWrapper] rendering ${pathname}; ${rateOkMessage}`)
     return <>{children}</>
 }

--- a/src/client/components/Wrappers/RateLimitWrapper/actions.ts
+++ b/src/client/components/Wrappers/RateLimitWrapper/actions.ts
@@ -1,4 +1,4 @@
-import { SHARED_Model__RateLimit } from '@/shared/models/models/RateLimit'
+import { SHARED_Model__RateLimitClientInfo } from '@/shared/models/models/RateLimit'
 
 export const RATE_LIMIT_LOADING = 'RATE_LIMIT_LOADING'
 export const RATE_LIMIT_UNAUTH = 'RATE_LIMIT_UNAUTH'
@@ -20,7 +20,7 @@ interface RateLimitAuthError {
 
 interface RateLimitAuthResponse {
     type: typeof RATE_LIMIT_AUTH_RESPONSE
-    rateLimit: SHARED_Model__RateLimit
+    rateLimit: SHARED_Model__RateLimitClientInfo
 }
 
 export type RateLimitWrapperAction = RateLimitLoading | RateLimitUnauth | RateLimitAuthError | RateLimitAuthResponse

--- a/src/client/components/Wrappers/RateLimitWrapper/actions.ts
+++ b/src/client/components/Wrappers/RateLimitWrapper/actions.ts
@@ -1,0 +1,26 @@
+import { SHARED_Model__RateLimit } from '@/shared/models/models/RateLimit'
+
+export const RATE_LIMIT_LOADING = 'RATE_LIMIT_LOADING'
+export const RATE_LIMIT_UNAUTH = 'RATE_LIMIT_UNAUTH'
+export const RATE_LIMIT_AUTH_ERROR = 'RATE_LIMIT_AUTH_ERROR'
+export const RATE_LIMIT_AUTH_RESPONSE = 'RATE_LIMIT_AUTH_RESPONSE'
+
+interface RateLimitLoading {
+    type: typeof RATE_LIMIT_LOADING
+}
+
+interface RateLimitUnauth {
+    type: typeof RATE_LIMIT_UNAUTH
+}
+
+interface RateLimitAuthError {
+    type: typeof RATE_LIMIT_AUTH_ERROR
+    error?: string
+}
+
+interface RateLimitAuthResponse {
+    type: typeof RATE_LIMIT_AUTH_RESPONSE
+    rateLimit: SHARED_Model__RateLimit
+}
+
+export type RateLimitWrapperAction = RateLimitLoading | RateLimitUnauth | RateLimitAuthError | RateLimitAuthResponse

--- a/src/client/components/Wrappers/RateLimitWrapper/index.ts
+++ b/src/client/components/Wrappers/RateLimitWrapper/index.ts
@@ -1,0 +1,2 @@
+import { RateLimitWrapper } from './RateLimitWrapper'
+export default RateLimitWrapper

--- a/src/client/components/Wrappers/RateLimitWrapper/reducer.ts
+++ b/src/client/components/Wrappers/RateLimitWrapper/reducer.ts
@@ -10,12 +10,12 @@ import { RateLimitWrapperState } from './RateLimitWrapper'
 export const reducer = (state: RateLimitWrapperState, action: RateLimitWrapperAction): RateLimitWrapperState => {
     switch (action.type) {
         case RATE_LIMIT_LOADING:
-            return { isLoading: true, error: undefined, rateLimit: undefined }
+            return { isLoading: true, error: undefined, rateLimitInfo: undefined }
         case RATE_LIMIT_UNAUTH:
-            return { isLoading: false, error: undefined, rateLimit: undefined }
+            return { isLoading: false, error: undefined, rateLimitInfo: undefined }
         case RATE_LIMIT_AUTH_ERROR:
-            return { isLoading: false, error: action.error, rateLimit: undefined }
+            return { isLoading: false, error: action.error, rateLimitInfo: undefined }
         case RATE_LIMIT_AUTH_RESPONSE:
-            return { isLoading: false, error: undefined, rateLimit: action.rateLimit }
+            return { isLoading: false, error: undefined, rateLimitInfo: action.rateLimit }
     }
 }

--- a/src/client/components/Wrappers/RateLimitWrapper/reducer.ts
+++ b/src/client/components/Wrappers/RateLimitWrapper/reducer.ts
@@ -1,0 +1,21 @@
+import {
+    RATE_LIMIT_AUTH_ERROR,
+    RATE_LIMIT_AUTH_RESPONSE,
+    RATE_LIMIT_LOADING,
+    RATE_LIMIT_UNAUTH,
+    RateLimitWrapperAction,
+} from './actions'
+import { RateLimitWrapperState } from './RateLimitWrapper'
+
+export const reducer = (state: RateLimitWrapperState, action: RateLimitWrapperAction): RateLimitWrapperState => {
+    switch (action.type) {
+        case RATE_LIMIT_LOADING:
+            return { isLoading: true, error: undefined, rateLimit: undefined }
+        case RATE_LIMIT_UNAUTH:
+            return { isLoading: false, error: undefined, rateLimit: undefined }
+        case RATE_LIMIT_AUTH_ERROR:
+            return { isLoading: false, error: action.error, rateLimit: undefined }
+        case RATE_LIMIT_AUTH_RESPONSE:
+            return { isLoading: false, error: undefined, rateLimit: action.rateLimit }
+    }
+}

--- a/src/client/lib/authAPI/index.ts
+++ b/src/client/lib/authAPI/index.ts
@@ -2,6 +2,7 @@ import { getAPIWithAuth } from '../fetchAPI'
 
 import { SHARED_APIFields__Contributions } from '@/shared/models/apiFields/contributions'
 import { SHARED_APIFields__LifetimeStats } from '@/shared/models/apiFields/lifetimeStats'
+import { SHARED_APIFields__RateLimit } from '@/shared/models/apiFields/rateLimit'
 import { SHARED_APIFields__UserCard } from '@/shared/models/apiFields/userCard'
 
 /*
@@ -24,4 +25,10 @@ export const contributionsAPI = async (accessToken: string): Promise<SHARED_APIF
     const res = await getAPIWithAuth('/api/contributions', accessToken)
     const contributionsRes = res as SHARED_APIFields__Contributions
     return contributionsRes
+}
+
+export const rateLimitAPI = async (accessToken: string): Promise<SHARED_APIFields__RateLimit> => {
+    const res = await getAPIWithAuth('/api/rate-limit', accessToken)
+    const rateLimitRes = res as SHARED_APIFields__RateLimit
+    return rateLimitRes
 }

--- a/src/server/lib/gh-api/rate-limit/index.ts
+++ b/src/server/lib/gh-api/rate-limit/index.ts
@@ -1,0 +1,23 @@
+import { BASE_GH_API_Call__getWithAuth, GH_API_Response__BASE } from '..'
+
+import { GH_API_Obj__RateLimit } from './model'
+
+interface GH_API_Response__rateLimit extends GH_API_Response__BASE {
+    allRateLimits?: GH_API_Obj__RateLimit
+}
+
+export const GH_API_Call__rateLimit = async (accessToken: string): Promise<GH_API_Response__rateLimit> => {
+    const url = '/rate_limit'
+
+    const res = await BASE_GH_API_Call__getWithAuth(url, accessToken)
+    const { status, statusText } = res
+
+    if (status !== 200) {
+        return { allRateLimits: undefined, success: false, error: `error ${status}: ${statusText}` }
+    }
+
+    const resJson: GH_API_Obj__RateLimit = (await res.json()) as GH_API_Obj__RateLimit
+    // console.log(resJson)
+
+    return { allRateLimits: resJson, success: true }
+}

--- a/src/server/lib/gh-api/rate-limit/model.ts
+++ b/src/server/lib/gh-api/rate-limit/model.ts
@@ -1,0 +1,23 @@
+export interface GH_API_Obj__RateLimitPerResource {
+    limit: number
+    used: number
+    remaining: number
+    reset: number
+}
+
+// https://docs.github.com/en/free-pro-team@latest/rest/rate-limit/rate-limit?apiVersion=2022-11-28#get-rate-limit-status-for-the-authenticated-user
+export interface GH_API_Obj__RateLimit {
+    resources: {
+        core: GH_API_Obj__RateLimitPerResource
+        search: GH_API_Obj__RateLimitPerResource
+        graphql: GH_API_Obj__RateLimitPerResource
+        integration_manifest: GH_API_Obj__RateLimitPerResource
+        source_import: GH_API_Obj__RateLimitPerResource
+        code_scanning_upload: GH_API_Obj__RateLimitPerResource
+        actions_runner_registration: GH_API_Obj__RateLimitPerResource
+        scim: GH_API_Obj__RateLimitPerResource
+        dependency_snapshots: GH_API_Obj__RateLimitPerResource
+        code_search: GH_API_Obj__RateLimitPerResource
+    }
+    rate: GH_API_Obj__RateLimitPerResource
+}

--- a/src/server/lib/gh-gql/RateLimit/index.ts
+++ b/src/server/lib/gh-gql/RateLimit/index.ts
@@ -1,0 +1,37 @@
+import { BASE_GH_GQL_Call__makeQueryWithAuth, GH_GQL_RawResponse_BASE, GH_GQL_Response__BASE } from '..'
+
+import { GH_GQL_Query__RateLimit, GH_GQL_Schema__RateLimit } from './query'
+
+interface GH_GQL_RawResponse__RateLimit extends GH_GQL_RawResponse_BASE {
+    data?: {
+        rateLimit: GH_GQL_Schema__RateLimit
+    }
+}
+
+export interface GH_GQL_Response__RateLimit extends GH_GQL_Response__BASE {
+    rateLimit?: GH_GQL_Schema__RateLimit
+}
+
+export const GH_GQL_Call__RateLimit = async (accessToken: string): Promise<GH_GQL_Response__RateLimit> => {
+    const res = await BASE_GH_GQL_Call__makeQueryWithAuth(accessToken, GH_GQL_Query__RateLimit)
+    const { status, statusText } = res
+
+    if (status !== 200) {
+        return { rateLimit: undefined, success: false, error: `error ${status}: ${statusText}` }
+    }
+
+    const resJson = (await res.json()) as GH_GQL_RawResponse__RateLimit
+    console.log(resJson)
+    const { data, errors: queryErrors } = resJson
+
+    if (data === undefined || queryErrors !== undefined) {
+        return {
+            rateLimit: undefined,
+            success: false,
+            error: `error: ${queryErrors !== undefined ? queryErrors[0].message : 'unknown (GraphQL)'}`,
+        }
+    }
+
+    const { rateLimit } = data
+    return { rateLimit: rateLimit, success: true }
+}

--- a/src/server/lib/gh-gql/RateLimit/query.ts
+++ b/src/server/lib/gh-gql/RateLimit/query.ts
@@ -1,0 +1,18 @@
+export const GH_GQL_Query__RateLimit = `query RateLimit {
+    rateLimit {
+        cost
+        limit
+        used
+        resetAt
+        remaining
+    }
+}
+`
+
+export interface GH_GQL_Schema__RateLimit {
+    cost: number
+    limit: number
+    used: number
+    resetAt: string // 2023-09-03T21:39:58Z
+    remaining: number
+}

--- a/src/server/services/allRepos/index.ts
+++ b/src/server/services/allRepos/index.ts
@@ -26,7 +26,7 @@ interface SERVICE_Response__countAllRepos extends SERVICE_Response__BASE {
     numRepos?: number
 }
 
-export const countAllRepos = async (accessToken: string): Promise<SERVICE_Response__countAllRepos> => {
+export const SERVICE_Call__countAllRepos = async (accessToken: string): Promise<SERVICE_Response__countAllRepos> => {
     const { success, error, numRepos } = await GH_API_Call__countRepos(accessToken)
 
     if (!success || numRepos === undefined) {
@@ -38,8 +38,8 @@ export const countAllRepos = async (accessToken: string): Promise<SERVICE_Respon
 
 type SERVICE_Response__listAllRepos = SERVICE_Response__listRepos
 
-export const listAllRepos = async (accessToken: string): Promise<SERVICE_Response__listAllRepos> => {
-    const { success: countSuccess, error: countError, numRepos } = await countAllRepos(accessToken)
+export const SERVICE_Call__listAllRepos = async (accessToken: string): Promise<SERVICE_Response__listAllRepos> => {
+    const { success: countSuccess, error: countError, numRepos } = await SERVICE_Call__countAllRepos(accessToken)
     // console.log(numRepos)
 
     if (!countSuccess || numRepos === undefined) {

--- a/src/server/services/countCommits/index.ts
+++ b/src/server/services/countCommits/index.ts
@@ -123,7 +123,10 @@ export const SERVICE_Call__countLifetimeCommits = async (
     accessToken: string,
 ): Promise<SERVICE_Response__countLifetimeCommits> => {
     try {
-        const [userRes, reposRes] = await Promise.all([GH_API_Call__getUser(accessToken), SERVICE_Call__listAllRepos(accessToken)])
+        const [userRes, reposRes] = await Promise.all([
+            GH_API_Call__getUser(accessToken),
+            SERVICE_Call__listAllRepos(accessToken),
+        ])
 
         const { success: userSuccess, error: userError, user } = userRes
         if (!userSuccess || user === undefined) {

--- a/src/server/services/countCommits/index.ts
+++ b/src/server/services/countCommits/index.ts
@@ -6,7 +6,7 @@ import {
     GH_API_Call__listCommits,
 } from '@/server/lib/gh-api/commits'
 import { GH_API_Call__getUser } from '@/server/lib/gh-api/users'
-import { listAllRepos } from '@/server/services/allRepos'
+import { SERVICE_Call__listAllRepos } from '@/server/services/allRepos'
 import { chunkArr } from '@/server/utils/chunkArr'
 import { SHARED_Model__Commit, SHARED_Model__CommitWithDiff } from '@/shared/models/models/Commits'
 import { SHARED_Model__Repo } from '@/shared/models/models/Repos'
@@ -123,7 +123,7 @@ export const SERVICE_Call__countLifetimeCommits = async (
     accessToken: string,
 ): Promise<SERVICE_Response__countLifetimeCommits> => {
     try {
-        const [userRes, reposRes] = await Promise.all([GH_API_Call__getUser(accessToken), listAllRepos(accessToken)])
+        const [userRes, reposRes] = await Promise.all([GH_API_Call__getUser(accessToken), SERVICE_Call__listAllRepos(accessToken)])
 
         const { success: userSuccess, error: userError, user } = userRes
         if (!userSuccess || user === undefined) {

--- a/src/server/services/lifetimeStats/index.ts
+++ b/src/server/services/lifetimeStats/index.ts
@@ -1,7 +1,8 @@
 import { SERVICE_Call__getAllReposWithCommitCounts } from '@/server/services/reposAndCommitCounts'
-import { SHARED_APIFields__LifetimeStats, SHARED_Model__LifetimeStats } from '@/shared/models/apiFields/lifetimeStats'
+import { SHARED_APIFields__LifetimeStats } from '@/shared/models/apiFields/lifetimeStats'
 import { SHARED_Model__AllLanguageStats, SHARED_Model__Language } from '@/shared/models/models/Language'
 import { SHARED_Model__RepoWithCommitCountsAndLanguages } from '@/shared/models/models/Repos'
+import { SHARED_Model__LifetimeStats } from '@/shared/models/models/Stats'
 import { SHARED_Model__RepoCommitCountStats } from '@/shared/models/models/Stats'
 
 const sharedRepoReduceLanguageStats = (

--- a/src/server/services/linesStats/index.ts
+++ b/src/server/services/linesStats/index.ts
@@ -16,7 +16,7 @@ interface SERVICE_Response__getContributorActivity extends SERVICE_Response__BAS
     activity?: SHARED_Model__ContributorCommitActivity
 }
 
-export const getContributorActivity = async (
+export const SERVICE_Call__getContributorActivity = async (
     accessToken: string,
     authUser: string,
     owner: string,
@@ -77,7 +77,9 @@ export const SERVICE_Call__computeLinesStatsAcrossReposUsingMetrics = async (
             for (; idx < repos.length && idx < startIdx + CHUNK_SIZE; idx++) {
                 const { owner, name: repoName } = repos[idx]
                 const { login: ownerLogin } = owner
-                activityPromiseChunk.push(getContributorActivity(accessToken, authUser, ownerLogin, repoName))
+                activityPromiseChunk.push(
+                    SERVICE_Call__getContributorActivity(accessToken, authUser, ownerLogin, repoName),
+                )
             }
 
             activities.push(...(await Promise.all(activityPromiseChunk)))

--- a/src/server/services/rateLimit/index.ts
+++ b/src/server/services/rateLimit/index.ts
@@ -1,0 +1,13 @@
+import { GH_GQL_Call__RateLimit } from '@/server/lib/gh-gql/RateLimit'
+import { SHARED_APIFields__RateLimit } from '@/shared/models/apiFields/rateLimit'
+import { SHARED_Model__RateLimit } from '@/shared/models/models/RateLimit'
+
+export const SERVICE_Call__getRateLimit = async (accessToken: string): Promise<SHARED_APIFields__RateLimit> => {
+    const { success: rateLimitSuccess, error: rateLimitError, rateLimit } = await GH_GQL_Call__RateLimit(accessToken)
+
+    if (!rateLimitSuccess || rateLimit === undefined) {
+        return { success: false, error: rateLimitError, rateLimit: undefined }
+    }
+
+    return { success: true, rateLimit: rateLimit as SHARED_Model__RateLimit }
+}

--- a/src/server/services/rateLimit/index.ts
+++ b/src/server/services/rateLimit/index.ts
@@ -1,6 +1,48 @@
+import { GH_API_Call__rateLimit } from '@/server/lib/gh-api/rate-limit'
 import { GH_GQL_Call__RateLimit } from '@/server/lib/gh-gql/RateLimit'
 import { SHARED_APIFields__RateLimit } from '@/shared/models/apiFields/rateLimit'
 import { SHARED_Model__RateLimit } from '@/shared/models/models/RateLimit'
+
+const isNearRateLimit = (rateLimitInfo: { used: number; limit: number; remaining: number }): boolean => {
+    const { limit, remaining } = rateLimitInfo
+    return remaining <= Math.max(limit * 0.02, 100)
+}
+
+const getResetDateStr = (resetAt: string | number): string => {
+    return new Date(resetAt).toLocaleDateString(undefined, {
+        year: 'numeric',
+        month: 'long',
+        day: 'numeric',
+        weekday: 'long',
+        hour: '2-digit',
+        minute: '2-digit',
+        second: '2-digit',
+    })
+}
+
+const getRateLimitedMessage = (
+    rateLimitInfo: {
+        used: number
+        limit: number
+        remaining: number
+        resetAtStr: string
+    },
+    isGraphql = true,
+): string => {
+    const { used, limit, remaining, resetAtStr } = rateLimitInfo
+    const rateLimitType = isGraphql ? 'GraphQL queries' : 'API requests'
+    return `Github imposes a rate limit of ${limit} ${rateLimitType}, and you have used ${used} (${remaining} remaining). Please retry after ${resetAtStr}.`
+}
+
+const getRateOkMessage = (rateLimitInfo: {
+    used: number
+    limit: number
+    remaining: number
+    resetAtStr: string
+}): string => {
+    const { used, limit, remaining, resetAtStr } = rateLimitInfo
+    return `Used ${used} queries out of Github API limit ${limit} (${remaining} remaining, resets at ${resetAtStr})`
+}
 
 export const SERVICE_Call__getRateLimit = async (accessToken: string): Promise<SHARED_APIFields__RateLimit> => {
     const { success: rateLimitSuccess, error: rateLimitError, rateLimit } = await GH_GQL_Call__RateLimit(accessToken)
@@ -9,23 +51,15 @@ export const SERVICE_Call__getRateLimit = async (accessToken: string): Promise<S
         return { success: false, error: rateLimitError, rateLimitClientInfo: undefined }
     }
 
-    const { used, limit, resetAt, remaining } = rateLimit
-    if (remaining <= Math.max(limit * 0.02, 100)) {
-        const resetDateStr = new Date(resetAt).toLocaleDateString(undefined, {
-            year: 'numeric',
-            month: 'long',
-            day: 'numeric',
-            weekday: 'long',
-            hour: '2-digit',
-            minute: '2-digit',
-            second: '2-digit',
-        })
+    const { resetAt } = rateLimit
+    const resetAtStr = getResetDateStr(resetAt)
+    if (isNearRateLimit({ ...rateLimit })) {
         return {
             success: true,
             rateLimitClientInfo: {
                 rateLimit: rateLimit as SHARED_Model__RateLimit,
                 isRateLimited: true,
-                rateLimitedMessage: `Github imposes an API rate limit of ${limit} queries, and you have used ${used} (${remaining} remaining). Please retry after ${resetDateStr}.`,
+                rateLimitedMessage: getRateLimitedMessage({ ...rateLimit, resetAtStr: resetAtStr }),
                 rateOkMessage: undefined,
             },
         }
@@ -37,7 +71,57 @@ export const SERVICE_Call__getRateLimit = async (accessToken: string): Promise<S
             rateLimit: rateLimit as SHARED_Model__RateLimit,
             isRateLimited: false,
             rateLimitedMessage: undefined,
-            rateOkMessage: `Used ${used} queries out of Github API limit ${limit} (${remaining} remaining)`,
+            rateOkMessage: getRateOkMessage({ ...rateLimit, resetAtStr: resetAtStr }),
+        },
+    }
+}
+
+export const SERVICE_Call__getRateLimitViaAPI = async (accessToken: string): Promise<SHARED_APIFields__RateLimit> => {
+    const {
+        success: rateLimitSuccess,
+        error: rateLimitError,
+        allRateLimits,
+    } = await GH_API_Call__rateLimit(accessToken)
+
+    if (!rateLimitSuccess || allRateLimits === undefined) {
+        return { success: false, error: rateLimitError, rateLimitClientInfo: undefined }
+    }
+
+    const { resources } = allRateLimits
+    const { core, graphql } = resources
+
+    if (isNearRateLimit({ ...core })) {
+        const { reset } = core
+        const resetAtStr = getResetDateStr(reset * 1000)
+        return {
+            success: true,
+            rateLimitClientInfo: {
+                isRateLimited: true,
+                rateLimitedMessage: getRateLimitedMessage({ ...core, resetAtStr: resetAtStr }, false),
+                rateOkMessage: undefined,
+            },
+        }
+    }
+
+    if (isNearRateLimit({ ...graphql })) {
+        const { reset } = graphql
+        const resetAtStr = getResetDateStr(reset * 1000)
+        return {
+            success: true,
+            rateLimitClientInfo: {
+                isRateLimited: true,
+                rateLimitedMessage: getRateLimitedMessage({ ...graphql, resetAtStr: resetAtStr }),
+                rateOkMessage: undefined,
+            },
+        }
+    }
+
+    return {
+        success: true,
+        rateLimitClientInfo: {
+            isRateLimited: false,
+            rateLimitedMessage: undefined,
+            rateOkMessage: getRateOkMessage({ ...core, resetAtStr: getResetDateStr(core.reset * 1000) }),
         },
     }
 }

--- a/src/shared/models/apiFields/lifetimeStats.ts
+++ b/src/shared/models/apiFields/lifetimeStats.ts
@@ -1,14 +1,6 @@
-import { SHARED_Model__AllLanguageStats } from '../models/Language'
-import { SHARED_Model__RepoWithCommitCountsAndLanguages } from '../models/Repos'
-import { SHARED_Model__RepoCommitCountStats } from '../models/Stats'
+import { SHARED_Model__LifetimeStats } from '../models/Stats'
 
 import { SHARED_APIFields__BASE } from '.'
-
-export interface SHARED_Model__LifetimeStats {
-    language_stats: SHARED_Model__AllLanguageStats
-    repos: SHARED_Model__RepoWithCommitCountsAndLanguages[]
-    rc_stats: SHARED_Model__RepoCommitCountStats
-}
 
 export interface SHARED_APIFields__LifetimeStats extends SHARED_APIFields__BASE {
     lifetimeStats?: SHARED_Model__LifetimeStats

--- a/src/shared/models/apiFields/rateLimit.ts
+++ b/src/shared/models/apiFields/rateLimit.ts
@@ -1,0 +1,7 @@
+import { SHARED_Model__RateLimit } from '../models/RateLimit'
+
+import { SHARED_APIFields__BASE } from '.'
+
+export interface SHARED_APIFields__RateLimit extends SHARED_APIFields__BASE {
+    rateLimit?: SHARED_Model__RateLimit
+}

--- a/src/shared/models/apiFields/rateLimit.ts
+++ b/src/shared/models/apiFields/rateLimit.ts
@@ -1,7 +1,7 @@
-import { SHARED_Model__RateLimit } from '../models/RateLimit'
+import { SHARED_Model__RateLimitClientInfo } from '../models/RateLimit'
 
 import { SHARED_APIFields__BASE } from '.'
 
 export interface SHARED_APIFields__RateLimit extends SHARED_APIFields__BASE {
-    rateLimit?: SHARED_Model__RateLimit
+    rateLimitClientInfo?: SHARED_Model__RateLimitClientInfo
 }

--- a/src/shared/models/models/RateLimit.ts
+++ b/src/shared/models/models/RateLimit.ts
@@ -1,0 +1,7 @@
+export interface SHARED_Model__RateLimit {
+    cost: number
+    limit: number
+    used: number
+    resetAt: string // 2023-09-03T21:39:58Z
+    remaining: number
+}

--- a/src/shared/models/models/RateLimit.ts
+++ b/src/shared/models/models/RateLimit.ts
@@ -7,7 +7,7 @@ export interface SHARED_Model__RateLimit {
 }
 
 export interface SHARED_Model__RateLimitClientInfo {
-    rateLimit: SHARED_Model__RateLimit
+    rateLimit?: SHARED_Model__RateLimit
     isRateLimited: boolean
     rateOkMessage?: string
     rateLimitedMessage?: string

--- a/src/shared/models/models/RateLimit.ts
+++ b/src/shared/models/models/RateLimit.ts
@@ -5,3 +5,10 @@ export interface SHARED_Model__RateLimit {
     resetAt: string // 2023-09-03T21:39:58Z
     remaining: number
 }
+
+export interface SHARED_Model__RateLimitClientInfo {
+    rateLimit: SHARED_Model__RateLimit
+    isRateLimited: boolean
+    rateOkMessage?: string
+    rateLimitedMessage?: string
+}

--- a/src/shared/models/models/Stats.ts
+++ b/src/shared/models/models/Stats.ts
@@ -1,3 +1,6 @@
+import { SHARED_Model__AllLanguageStats } from './Language'
+import { SHARED_Model__RepoWithCommitCountsAndLanguages } from './Repos'
+
 export const makeLinesStats = (): SHARED_Model__LinesStats => {
     return {
         numAdditions: 0,
@@ -15,4 +18,10 @@ export interface SHARED_Model__LinesStats {
 export interface SHARED_Model__RepoCommitCountStats {
     numRepos: number
     numCommits: number
+}
+
+export interface SHARED_Model__LifetimeStats {
+    language_stats: SHARED_Model__AllLanguageStats
+    repos: SHARED_Model__RepoWithCommitCountsAndLanguages[]
+    rc_stats: SHARED_Model__RepoCommitCountStats
 }


### PR DESCRIPTION
- implement rate limiting based on GH OAuth app GraphQL/core API usage rate limits
- basic server-side request logic + client-side handling via `RateLimitWrapper`
- includes both GraphQL query and API request routes; currently using API to avoid counting towards rate limit